### PR TITLE
Fix to match if all attributes match only

### DIFF
--- a/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/dispatchers/task/AttributeMatchTaskDispatchPolicy.java
+++ b/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/dispatchers/task/AttributeMatchTaskDispatchPolicy.java
@@ -153,6 +153,9 @@ public class AttributeMatchTaskDispatchPolicy implements TaskDispatchPolicy, Ext
                         matches = false;
                     }
                 }
+                
+                if (!matches)
+                    break;
             }
 
             if (matches)


### PR DESCRIPTION
Fix to match if all attributes match only (previously matched if only one attribute was matching)
