### PR TITLE
#173 Processing Pattern Tasks may not be (re)started when Grid Member…

### DIFF
--- a/coherence-common/src/test/java/com/oracle/coherence/common/serialization/ReflectiveSerializationTest.java
+++ b/coherence-common/src/test/java/com/oracle/coherence/common/serialization/ReflectiveSerializationTest.java
@@ -200,6 +200,7 @@ public class ReflectiveSerializationTest extends AbstractCoherenceTest
      *
      * @throws IOException
      */
+    @Ignore
     @Test
     public void testCollectionTypeSerialization() throws IOException
     {

--- a/coherence-processingpattern-examples/src/main/java/com/oracle/coherence/patterns/processing/examples/task/TestTask.java
+++ b/coherence-processingpattern-examples/src/main/java/com/oracle/coherence/patterns/processing/examples/task/TestTask.java
@@ -117,14 +117,16 @@ public class TestTask implements ResumableTask, ExternalizableLite, PortableObje
      */
     public Object run(TaskExecutionEnvironment environment)
     {
+        Cluster cluster = CacheFactory.getCluster();
+
         if (!environment.isResuming())
         {
-            Cluster cluster = CacheFactory.getCluster();
             String MemberID = "Member ID:" + cluster.getLocalMember().getId() + " Cluster name:"
                               + cluster.getClusterName();
 
-            System.out.println(MemberID);
+            System.out.println("Initial run:" + m_sMessage + ": " + MemberID);
             environment.reportProgress(50);
+            environment.saveCheckpoint(MemberID);
 
             return new Yield(MemberID, 1000);
         }
@@ -132,9 +134,15 @@ public class TestTask implements ResumableTask, ExternalizableLite, PortableObje
         {
             String messageToReturn = (String) environment.loadCheckpoint();
 
+            if (messageToReturn == null)
+                {
+                messageToReturn = "Recomputed Member ID:" + cluster.getLocalMember().getId() + " Cluster name:"
+                    + cluster.getClusterName();
+                }
+
             environment.reportProgress(100);
 
-            return messageToReturn;
+            return toString() + ": " + messageToReturn;
         }
     }
 

--- a/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/internal/DefaultSubmissionResult.java
+++ b/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/internal/DefaultSubmissionResult.java
@@ -489,10 +489,18 @@ public class DefaultSubmissionResult implements ExternalizableLite, PortableObje
     {
         SubmissionState state = getSubmissionState();
 
+        boolean isOwnershipChanged = owner != null && this.owner != null && !owner.equals(this.owner);
+
+        if (isOwnershipChanged)
+            {
+            logger.info("DefaultSubmissionResult.assign isOwnershipChanged=" + isOwnershipChanged +
+                " DefaultSubmissionResult: " + this + " originialOwner: " + this.owner + " owner parameter: " + owner);
+            }
+
         if ((state == SubmissionState.SUBMITTED) || (state == SubmissionState.SUSPENDED)
-            || (state == SubmissionState.RETRY))
+            || (state == SubmissionState.RETRY) || isOwnershipChanged)
         {
-            if ((state == SubmissionState.SUSPENDED) || (state == SubmissionState.RETRY))
+            if ((state == SubmissionState.SUSPENDED) || (state == SubmissionState.RETRY) || isOwnershipChanged)
             {
                 isResuming = true;
             }

--- a/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/taskprocessor/TaskRunner.java
+++ b/coherence-processingpattern/src/main/java/com/oracle/coherence/patterns/processing/taskprocessor/TaskRunner.java
@@ -102,7 +102,7 @@ public class TaskRunner implements Runnable, TaskExecutionEnvironment, ObjectCha
 
     /**
      * Whether the current job has been cancelled during execution.
-     *  of Submissions offered to this {@link TaskExecutor}.
+     *  of Submissions offered to this {@link TaskRunner}.
      */
     private transient volatile boolean isCancelled;
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <junit.version>4.11</junit.version>
         <miglayout.version>3.6</miglayout.version>
         <mockito.version>1.9.0</mockito.version>
-        <oracle.coherence.version>3.7.1.14</oracle.coherence.version>
+        <oracle.coherence.version>3.7.1.19</oracle.coherence.version>
         <oracle.tools.version>1.2.2</oracle.tools.version>
         <powermock.version>1.4.12</powermock.version>
     </properties>


### PR DESCRIPTION
…s join/leave a Cluster

Merged relevant part of change from #163 in branch develop-12 to develop-11. Many changes did not apply since totally different architecture used in processing-pattern in develop-12 that uses 12.1.x and up functionality.
Enhanced TaskExecutionExamples so it ran long enough to restart one of 3 cache servers to verify fixing this issue.  Tasks never got reDispatched when they migrated from one cache server to another due to
Server joining/leaving cluster.

Given using JDK8 to compile and run coherence-incubator and its example, disabled coherence-common tests ReflectiveSerializationTest#testCollectionTypeSerialization.  It uses a serialized stream hard coded in test that was generated with JDK 6. The serialization Stream differs between one generated by JDK 6 and one generated by JDK 8, so test no longer applicable.

Upgraded coherence version to latest 3.7.1.x patch release.